### PR TITLE
Empty default value in bitfields

### DIFF
--- a/extract.py
+++ b/extract.py
@@ -33,6 +33,7 @@ fontspec_to_meaning = [
   ({'color': '#000000', 'family': 'ABCDEE+Calibri,Bold', 'size': '18'}, "h3-garbage-if-empty"), # Otherwise it throws off table header detection--and the text is empty anyway
   ({'color': '#000000', 'family': 'Times New Roman,BoldItalic', 'size': 15}, "garbage-if-empty"),
   ({'color': '#000000', 'family': 'Times New Roman', 'size': '15'}, "garbage-if-empty"),
+  ({'color': '#000000', 'family': 'ABCDEE+Calibri,Bold', 'size': '36'}, "h0"),
 ]
 
 def hashable_fontspec(d):

--- a/extract.py
+++ b/extract.py
@@ -208,6 +208,8 @@ class State(object):
       return
     if attrib["meaning"] == "h3-garbage-if-empty":
       attrib["meaning"] = "h3"
+    if self.in_table == "TSF_CSR" and attrib["meaning"] == "table-cell" and text.startswith("TSFGSR"):
+       print("'R/W', \r'0',") #A64 restore missing
     #print(">" + text + "<", attrib, xx, file=sys.stderr)
     #if text.strip() == "Module Name" and self.page_number == '81':
     #  import pdb

--- a/phase3.py
+++ b/phase3.py
@@ -95,7 +95,7 @@ def clean_table(module, header, body, name):
       for i, x in enumerate(row):
           if len(nrow) >= len(suffix):
             nrow.append(x)
-          elif x != " ":
+          elif x != " " or (len(nrow) == len(suffix) - 2): #pass " " to Default/Hex field
             nrow.append(x)
       row[:] = nrow
     number_of_access_specs = len([x for x in suffix if x.find("Read/Write") != -1])


### PR DESCRIPTION
    phase3: A64 and others have few birtield specs with empty Default field.
    this fix allows to include these bitfields in final svd file.
    fields example for A64:
    HCCPARAMS:Isochronous Scheduling Threshold
    HCCPARAMS:Asynchronous Schedule Park Capability
    HCCPARAMS:Programmable Frame List Flag
    Also this change makes few other field names more correct.